### PR TITLE
Updating vendored gcd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,13 +9,13 @@
     "gcdapi",
     "gcdmessage"
   ]
-  revision = "daea95af954a7d99b9c8fdb669a6d6626087cafa"
+  revision = "3231a1db3b2236110c12850400000c9624168272"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["websocket"]
-  revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
+  revision = "4cb1c02c05b0e749b0365f61ae859a8e0cfceed9"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/tab.go
+++ b/tab.go
@@ -997,7 +997,9 @@ func (t *Tab) DeleteCookie(cookieName, url string) error {
 
 // Override the user agent for requests going out.
 func (t *Tab) SetUserAgent(userAgent string) error {
-	_, err := t.Network.SetUserAgentOverride(userAgent)
+	_, err := t.Network.SetUserAgentOverrideWithParams(&gcdapi.NetworkSetUserAgentOverrideParams{
+		UserAgent: userAgent,
+	})
 	return err
 }
 

--- a/vendor/github.com/wirepair/gcd/CHANGELOG.md
+++ b/vendor/github.com/wirepair/gcd/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog (2018)
+- June 1st: Updated to latest gcd / protocol.json file for 67.0.3396.62 for *stable* branch.
 - April 24th: Updated to latest gcd / protocol.json file for 66.0.3359.117 for *stable* branch. Please note there was a change to protocol files again, more details: https://github.com/wirepair/gcd/issues/21.
 - Feburary 22nd: Updated to latest gcd / protocol.json file for 66.0.3346.8. Added dep init/dep ensure to repository for package management.
 - January 17th: Updated to latest protocol. Removed examples from README.md because API changes too often, added a link to examples instead which I ensure work after update. Fixed \n in descriptions of protocol.json files causing template generation errors. Current is 65.0.3322.3. Updated examples to work with latest API changes.

--- a/vendor/github.com/wirepair/gcd/gcd.go
+++ b/vendor/github.com/wirepair/gcd/gcd.go
@@ -37,7 +37,7 @@ import (
 	"github.com/wirepair/gcd/gcdapi"
 )
 
-var GCDVERSION = "1.2018.4.24.0"
+var GCDVERSION = "1.2018.6.1.0"
 
 // When we get an error reading the body from the debugger api endpoint
 type GcdBodyReadErr struct {

--- a/vendor/github.com/wirepair/gcd/gcdapi/accessibility.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/accessibility.go
@@ -31,7 +31,7 @@ type AccessibilityAXRelatedNode struct {
 
 // No Description.
 type AccessibilityAXProperty struct {
-	Name  string                `json:"name"`  // The name of this property. enum values: busy, disabled, hidden, hiddenRoot, invalid, keyshortcuts, roledescription, live, atomic, relevant, root, autocomplete, haspopup, level, multiselectable, orientation, multiline, readonly, required, valuemin, valuemax, valuetext, checked, expanded, modal, pressed, selected, activedescendant, controls, describedby, details, errormessage, flowto, labelledby, owns
+	Name  string                `json:"name"`  // The name of this property. enum values: busy, disabled, hidden, hiddenRoot, invalid, keyshortcuts, roledescription, live, atomic, relevant, root, autocomplete, hasPopup, level, multiselectable, orientation, multiline, readonly, required, valuemin, valuemax, valuetext, checked, expanded, modal, pressed, selected, activedescendant, controls, describedby, details, errormessage, flowto, labelledby, owns
 	Value *AccessibilityAXValue `json:"value"` // The value of this property.
 }
 

--- a/vendor/github.com/wirepair/gcd/gcdapi/debugger.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/debugger.go
@@ -208,6 +208,8 @@ type DebuggerEvaluateOnCallFrameParams struct {
 	GeneratePreview bool `json:"generatePreview,omitempty"`
 	// Whether to throw an exception if side effect cannot be ruled out during evaluation.
 	ThrowOnSideEffect bool `json:"throwOnSideEffect,omitempty"`
+	// Terminate execution after timing out (number of milliseconds).
+	Timeout float64 `json:"timeout,omitempty"`
 }
 
 // EvaluateOnCallFrameWithParams - Evaluates expression on a given call frame.
@@ -252,8 +254,9 @@ func (c *Debugger) EvaluateOnCallFrameWithParams(v *DebuggerEvaluateOnCallFrameP
 // returnByValue - Whether the result is expected to be a JSON object that should be sent by value.
 // generatePreview - Whether preview should be generated for the result.
 // throwOnSideEffect - Whether to throw an exception if side effect cannot be ruled out during evaluation.
+// timeout - Terminate execution after timing out (number of milliseconds).
 // Returns -  result - Object wrapper for the evaluation result. exceptionDetails - Exception details.
-func (c *Debugger) EvaluateOnCallFrame(callFrameId string, expression string, objectGroup string, includeCommandLineAPI bool, silent bool, returnByValue bool, generatePreview bool, throwOnSideEffect bool) (*RuntimeRemoteObject, *RuntimeExceptionDetails, error) {
+func (c *Debugger) EvaluateOnCallFrame(callFrameId string, expression string, objectGroup string, includeCommandLineAPI bool, silent bool, returnByValue bool, generatePreview bool, throwOnSideEffect bool, timeout float64) (*RuntimeRemoteObject, *RuntimeExceptionDetails, error) {
 	var v DebuggerEvaluateOnCallFrameParams
 	v.CallFrameId = callFrameId
 	v.Expression = expression
@@ -263,6 +266,7 @@ func (c *Debugger) EvaluateOnCallFrame(callFrameId string, expression string, ob
 	v.ReturnByValue = returnByValue
 	v.GeneratePreview = generatePreview
 	v.ThrowOnSideEffect = throwOnSideEffect
+	v.Timeout = timeout
 	return c.EvaluateOnCallFrameWithParams(&v)
 }
 

--- a/vendor/github.com/wirepair/gcd/gcdapi/domsnapshot.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/domsnapshot.go
@@ -38,6 +38,7 @@ type DOMSnapshotDOMNode struct {
 	IsClickable           bool                        `json:"isClickable,omitempty"`           // Whether this DOM node responds to mouse clicks. This includes nodes that have had click event listeners attached via JavaScript as well as anchor tags that naturally navigate when clicked.
 	EventListeners        []*DOMDebuggerEventListener `json:"eventListeners,omitempty"`        // Details of the node's event listeners, if any.
 	CurrentSourceURL      string                      `json:"currentSourceURL,omitempty"`      // The selected url for nodes with a srcset attribute.
+	OriginURL             string                      `json:"originURL,omitempty"`             // The url of the script (if any) that generates this node.
 }
 
 // Details of post layout rendered text positions. The exact layout should not be regarded as stable and may change between versions.
@@ -75,6 +76,16 @@ type DOMSnapshot struct {
 func NewDOMSnapshot(target gcdmessage.ChromeTargeter) *DOMSnapshot {
 	c := &DOMSnapshot{target: target}
 	return c
+}
+
+// Disables DOM snapshot agent for the given page.
+func (c *DOMSnapshot) Disable() (*gcdmessage.ChromeResponse, error) {
+	return gcdmessage.SendDefaultRequest(c.target, c.target.GetSendCh(), &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "DOMSnapshot.disable"})
+}
+
+// Enables DOM snapshot agent for the given page.
+func (c *DOMSnapshot) Enable() (*gcdmessage.ChromeResponse, error) {
+	return gcdmessage.SendDefaultRequest(c.target, c.target.GetSendCh(), &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "DOMSnapshot.enable"})
 }
 
 type DOMSnapshotGetSnapshotParams struct {

--- a/vendor/github.com/wirepair/gcd/gcdapi/headlessexperimental.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/headlessexperimental.go
@@ -33,14 +33,8 @@ func NewHeadlessExperimental(target gcdmessage.ChromeTargeter) *HeadlessExperime
 }
 
 type HeadlessExperimentalBeginFrameParams struct {
-	// Timestamp of this BeginFrame (milliseconds since epoch). If not set, the current time will be used unless frameTicks is specified.
-	FrameTime float64 `json:"frameTime,omitempty"`
-	// Timestamp of this BeginFrame in Renderer TimeTicks (milliseconds of uptime). If not set, the current time will be used unless frameTime is specified.
+	// Timestamp of this BeginFrame in Renderer TimeTicks (milliseconds of uptime). If not set, the current time will be used.
 	FrameTimeTicks float64 `json:"frameTimeTicks,omitempty"`
-	// Deadline of this BeginFrame (milliseconds since epoch). If not set, the deadline will be calculated from the frameTime and interval unless deadlineTicks is specified.
-	Deadline float64 `json:"deadline,omitempty"`
-	// Deadline of this BeginFrame in Renderer TimeTicks  (milliseconds of uptime). If not set, the deadline will be calculated from the frameTime and interval unless deadline is specified.
-	DeadlineTicks float64 `json:"deadlineTicks,omitempty"`
 	// The interval between BeginFrames that is reported to the compositor, in milliseconds. Defaults to a 60 frames/second interval, i.e. about 16.666 milliseconds.
 	Interval float64 `json:"interval,omitempty"`
 	// Whether updates should not be committed and drawn onto the display. False by default. If true, only side effects of the BeginFrame will be run, such as layout and animations, but any visual updates may not be visible on the display or in screenshots.
@@ -83,42 +77,18 @@ func (c *HeadlessExperimental) BeginFrameWithParams(v *HeadlessExperimentalBegin
 }
 
 // BeginFrame - Sends a BeginFrame to the target and returns when the frame was completed. Optionally captures a screenshot from the resulting frame. Requires that the target was created with enabled BeginFrameControl. Designed for use with --run-all-compositor-stages-before-draw, see also https://goo.gl/3zHXhB for more background.
-// frameTime - Timestamp of this BeginFrame (milliseconds since epoch). If not set, the current time will be used unless frameTicks is specified.
-// frameTimeTicks - Timestamp of this BeginFrame in Renderer TimeTicks (milliseconds of uptime). If not set, the current time will be used unless frameTime is specified.
-// deadline - Deadline of this BeginFrame (milliseconds since epoch). If not set, the deadline will be calculated from the frameTime and interval unless deadlineTicks is specified.
-// deadlineTicks - Deadline of this BeginFrame in Renderer TimeTicks  (milliseconds of uptime). If not set, the deadline will be calculated from the frameTime and interval unless deadline is specified.
+// frameTimeTicks - Timestamp of this BeginFrame in Renderer TimeTicks (milliseconds of uptime). If not set, the current time will be used.
 // interval - The interval between BeginFrames that is reported to the compositor, in milliseconds. Defaults to a 60 frames/second interval, i.e. about 16.666 milliseconds.
 // noDisplayUpdates - Whether updates should not be committed and drawn onto the display. False by default. If true, only side effects of the BeginFrame will be run, such as layout and animations, but any visual updates may not be visible on the display or in screenshots.
 // screenshot - If set, a screenshot of the frame will be captured and returned in the response. Otherwise, no screenshot will be captured. Note that capturing a screenshot can fail, for example, during renderer initialization. In such a case, no screenshot data will be returned.
 // Returns -  hasDamage - Whether the BeginFrame resulted in damage and, thus, a new frame was committed to the display. Reported for diagnostic uses, may be removed in the future. screenshotData - Base64-encoded image data of the screenshot, if one was requested and successfully taken.
-func (c *HeadlessExperimental) BeginFrame(frameTime float64, frameTimeTicks float64, deadline float64, deadlineTicks float64, interval float64, noDisplayUpdates bool, screenshot *HeadlessExperimentalScreenshotParams) (bool, string, error) {
+func (c *HeadlessExperimental) BeginFrame(frameTimeTicks float64, interval float64, noDisplayUpdates bool, screenshot *HeadlessExperimentalScreenshotParams) (bool, string, error) {
 	var v HeadlessExperimentalBeginFrameParams
-	v.FrameTime = frameTime
 	v.FrameTimeTicks = frameTimeTicks
-	v.Deadline = deadline
-	v.DeadlineTicks = deadlineTicks
 	v.Interval = interval
 	v.NoDisplayUpdates = noDisplayUpdates
 	v.Screenshot = screenshot
 	return c.BeginFrameWithParams(&v)
-}
-
-type HeadlessExperimentalEnterDeterministicModeParams struct {
-	// Number of seconds since the Epoch
-	InitialDate float64 `json:"initialDate,omitempty"`
-}
-
-// EnterDeterministicModeWithParams - Puts the browser into deterministic mode.  Only effective for subsequently created web contents. Only supported in headless mode.  Once set there's no way of leaving deterministic mode.
-func (c *HeadlessExperimental) EnterDeterministicModeWithParams(v *HeadlessExperimentalEnterDeterministicModeParams) (*gcdmessage.ChromeResponse, error) {
-	return gcdmessage.SendDefaultRequest(c.target, c.target.GetSendCh(), &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "HeadlessExperimental.enterDeterministicMode", Params: v})
-}
-
-// EnterDeterministicMode - Puts the browser into deterministic mode.  Only effective for subsequently created web contents. Only supported in headless mode.  Once set there's no way of leaving deterministic mode.
-// initialDate - Number of seconds since the Epoch
-func (c *HeadlessExperimental) EnterDeterministicMode(initialDate float64) (*gcdmessage.ChromeResponse, error) {
-	var v HeadlessExperimentalEnterDeterministicModeParams
-	v.InitialDate = initialDate
-	return c.EnterDeterministicModeWithParams(&v)
 }
 
 // Disables headless events for the target.

--- a/vendor/github.com/wirepair/gcd/gcdapi/io.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/io.go
@@ -39,7 +39,7 @@ func (c *IO) Close(handle string) (*gcdmessage.ChromeResponse, error) {
 type IOReadParams struct {
 	// Handle of the stream to read.
 	Handle string `json:"handle"`
-	// Seek to the specified offset before reading (if not specificed, proceed with offset following the last read).
+	// Seek to the specified offset before reading (if not specificed, proceed with offset following the last read). Some types of streams may only support sequential reads.
 	Offset int `json:"offset,omitempty"`
 	// Maximum number of bytes to read (left upon the agent discretion if not specified).
 	Size int `json:"size,omitempty"`
@@ -81,7 +81,7 @@ func (c *IO) ReadWithParams(v *IOReadParams) (bool, string, bool, error) {
 
 // Read - Read a chunk of the stream
 // handle - Handle of the stream to read.
-// offset - Seek to the specified offset before reading (if not specificed, proceed with offset following the last read).
+// offset - Seek to the specified offset before reading (if not specificed, proceed with offset following the last read). Some types of streams may only support sequential reads.
 // size - Maximum number of bytes to read (left upon the agent discretion if not specified).
 // Returns -  base64Encoded - Set if the data is base64-encoded data - Data that were read. eof - Set if the end-of-file condition occured while reading.
 func (c *IO) Read(handle string, offset int, size int) (bool, string, bool, error) {

--- a/vendor/github.com/wirepair/gcd/gcdapi/page.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/page.go
@@ -24,7 +24,7 @@ type PageFrame struct {
 // Information about the Resource on the page.
 type PageFrameResource struct {
 	Url          string  `json:"url"`                    // Resource URL.
-	Type         string  `json:"type"`                   // Type of this resource. enum values: Document, Stylesheet, Image, Media, Font, Script, TextTrack, XHR, Fetch, EventSource, WebSocket, Manifest, Other
+	Type         string  `json:"type"`                   // Type of this resource. enum values: Document, Stylesheet, Image, Media, Font, Script, TextTrack, XHR, Fetch, EventSource, WebSocket, Manifest, SignedExchange, Other
 	MimeType     string  `json:"mimeType"`               // Resource mimeType as determined by the browser.
 	LastModified float64 `json:"lastModified,omitempty"` // last-modified timestamp as reported by server.
 	ContentSize  float64 `json:"contentSize,omitempty"`  // Resource content size.
@@ -1382,6 +1382,29 @@ func (c *Page) StopLoading() (*gcdmessage.ChromeResponse, error) {
 // Crashes renderer on the IO thread, generates minidumps.
 func (c *Page) Crash() (*gcdmessage.ChromeResponse, error) {
 	return gcdmessage.SendDefaultRequest(c.target, c.target.GetSendCh(), &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "Page.crash"})
+}
+
+// Tries to close page, running its beforeunload hooks, if any.
+func (c *Page) Close() (*gcdmessage.ChromeResponse, error) {
+	return gcdmessage.SendDefaultRequest(c.target, c.target.GetSendCh(), &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "Page.close"})
+}
+
+type PageSetWebLifecycleStateParams struct {
+	// Target lifecycle state
+	State string `json:"state"`
+}
+
+// SetWebLifecycleStateWithParams - Tries to update the web lifecycle state of the page. It will transition the page to the given state according to: https://github.com/WICG/web-lifecycle/
+func (c *Page) SetWebLifecycleStateWithParams(v *PageSetWebLifecycleStateParams) (*gcdmessage.ChromeResponse, error) {
+	return gcdmessage.SendDefaultRequest(c.target, c.target.GetSendCh(), &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "Page.setWebLifecycleState", Params: v})
+}
+
+// SetWebLifecycleState - Tries to update the web lifecycle state of the page. It will transition the page to the given state according to: https://github.com/WICG/web-lifecycle/
+// state - Target lifecycle state
+func (c *Page) SetWebLifecycleState(state string) (*gcdmessage.ChromeResponse, error) {
+	var v PageSetWebLifecycleStateParams
+	v.State = state
+	return c.SetWebLifecycleStateWithParams(&v)
 }
 
 // Stops sending each frame in the `screencastFrame`.

--- a/vendor/github.com/wirepair/gcd/gcdapi/version.go
+++ b/vendor/github.com/wirepair/gcd/gcdapi/version.go
@@ -3,4 +3,4 @@ package gcdapi
 // Chrome Channel information
 const CHROME_CHANNEL = "stable" 
 // Chrome Version information
-const CHROME_VERSION = "66.0.3359.117"
+const CHROME_VERSION = "67.0.3396.62"

--- a/vendor/golang.org/x/net/websocket/websocket.go
+++ b/vendor/golang.org/x/net/websocket/websocket.go
@@ -241,7 +241,10 @@ func (ws *Conn) Close() error {
 	return err1
 }
 
+// IsClientConn reports whether ws is a client-side connection.
 func (ws *Conn) IsClientConn() bool { return ws.request == nil }
+
+// IsServerConn reports whether ws is a server-side connection.
 func (ws *Conn) IsServerConn() bool { return ws.request != nil }
 
 // LocalAddr returns the WebSocket Origin for the connection for client, or


### PR DESCRIPTION
My build was failing when using this library with `dep ensure`.
Here is the error:
```
vendor\github.com\wirepair\autogcd\tab.go:1000:42: not enough arguments in call to t.ChromeTarget.Network.SetUserAgentOverride
        have (string)
        want (string, string, string)
```

After this change, my build began working.